### PR TITLE
make LinearSolve a weak dep, add compat bounds

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AffineRayleighOptimization"
 uuid = "afc0e0ae-cd0a-41ee-b0f5-7950de095d62"
 authors = ["William Samuelson <william.samuelson@gmail.com> and contributors"]
-version = "1.0.0-DEV"
+version = "1.1.0-DEV"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/Project.toml
+++ b/Project.toml
@@ -5,17 +5,30 @@ version = "1.0.0-DEV"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
-LinearSolve = "7ed4a6bd-45f5-4d41-b270-4a48e9bafcae"
 SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 TestItems = "1c621080-faea-4a02-84b6-bbd5e436b8fe"
 
+[weakdeps]
+LinearSolve = "7ed4a6bd-45f5-4d41-b270-4a48e9bafcae"
+
+[extensions]
+AffineRayleighOptimizationLinearSolveExt = "LinearSolve"
+
 [compat]
-julia = "1.6.7"
+LinearAlgebra = "1"
+SciMLBase = "2"
+TestItems = "0.1"
+julia = "1.9"
+LinearSolve = "2"
+TestItemRunner = "0.2"
+Test = "1"
+Random = "1"
 
 [extras]
+LinearSolve = "7ed4a6bd-45f5-4d41-b270-4a48e9bafcae"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 TestItemRunner = "f8b46487-2199-4994-9208-9a1283c18c0a"
 
 [targets]
-test = ["Test", "TestItemRunner", "Random"]
+test = ["Test", "TestItemRunner", "Random", "LinearSolve"]

--- a/ext/AffineRayleighOptimizationLinearSolveExt.jl
+++ b/ext/AffineRayleighOptimizationLinearSolveExt.jl
@@ -1,0 +1,30 @@
+module AffineRayleighOptimizationLinearSolveExt
+
+using AffineRayleighOptimization
+using LinearAlgebra
+using LinearSolve
+
+
+struct ConstrainedQuadraticFormLinearSolveSolver{LP,TM}
+    linearprob::LP
+    transform_matrix::TM
+end
+
+function AffineRayleighOptimization.init(prob::ConstrainedQuadraticFormProblem, alg::A, args...; kwargs...) where {A<:Union{<:SciMLBase.AbstractLinearAlgorithm,<:QF_LINEARSOLVE}}
+    inv_penalty_mat = inv(prob.Q.quadratic_form)
+    original_lhs_mat = prob.C
+    tm = inv_penalty_mat * original_lhs_mat'
+    new_lhs = Hermitian(original_lhs_mat * tm)
+    linearprob = init(LinearProblem(new_lhs, prob.b; kwargs...), alg, args...; kwargs...)
+    ConstrainedQuadraticFormLinearSolveSolver(linearprob, tm)
+end
+
+AffineRayleighOptimization.init(prob::LinearProblem, alg::QF_LINEARSOLVE{A}; kwargs...) where {A<:SciMLBase.AbstractLinearAlgorithm} = init(prob, alg.alg; kwargs...)
+
+
+function AffineRayleighOptimization.solve!(prob::ConstrainedQuadraticFormLinearSolveSolver)
+    intermediate_sol = solve!(prob.linearprob)
+    return prob.transform_matrix * intermediate_sol
+end
+
+end

--- a/src/AffineRayleighOptimization.jl
+++ b/src/AffineRayleighOptimization.jl
@@ -1,11 +1,12 @@
 module AffineRayleighOptimization
 using LinearAlgebra
-using LinearSolve
-import SciMLBase: solve
+import SciMLBase: solve, init, solve!
 using TestItems
 
 export RayleighQuotient, QuadraticForm
 export ConstrainedRayleighQuotientProblem, ConstrainedQuadraticFormProblem
+export QF_BACKSLASH, QF_LINEARSOLVE
+
 export solve
 
 include("quadratic_form.jl")

--- a/src/quadratic_form.jl
+++ b/src/quadratic_form.jl
@@ -38,14 +38,30 @@ function ConstrainedQuadraticFormProblem(Q, C, b)
     return ConstrainedQuadraticFormProblem(QuadraticForm(Q), C, b)
 end
 
+abstract type QF_ALG end
+struct QF_BACKSLASH <: QF_ALG end
+
+struct ConstrainedQuadraticFormBackslashSolver{L,B,TM}
+    lhs::L
+    b::B
+    transform_matrix::TM
+end
+default_linear_alg(prob::ConstrainedQuadraticFormProblem) = QF_BACKSLASH()
+
 # https://dept.math.lsa.umich.edu/~speyer/417/Minimization.pdf
-function solve(prob::ConstrainedQuadraticFormProblem, alg=KrylovJL_MINRES())
+function init(prob::ConstrainedQuadraticFormProblem, alg::QF_BACKSLASH=default_linear_alg(prob))
     inv_penalty_mat = inv(prob.Q.quadratic_form)
     original_lhs_mat = prob.C
-    new_lhs = Hermitian(original_lhs_mat * inv_penalty_mat * original_lhs_mat')
-    intermediate_sol = solve(LinearProblem(new_lhs, prob.b), alg).u
-    return inv_penalty_mat * original_lhs_mat' * intermediate_sol
+    tm = inv_penalty_mat * original_lhs_mat'
+    new_lhs = Hermitian(original_lhs_mat * tm)
+    ConstrainedQuadraticFormBackslashSolver(new_lhs, prob.b, tm)
 end
+
+function solve!(prob::ConstrainedQuadraticFormBackslashSolver)
+    intermediate_sol = prob.lhs \ prob.b
+    return prob.transform_matrix * intermediate_sol
+end
+
 
 @testitem "QuadraticFormProblem" begin
     using LinearAlgebra, Random
@@ -56,4 +72,18 @@ end
     prob = ConstrainedQuadraticFormProblem(Q, C, b)
     sol = solve(prob)
     @test sol ≈ b
+    using LinearSolve
+    sol = solve(prob, QF_LINEARSOLVE()) #Will use the default solver from LinearSolve
+    @test sol ≈ b
+    sol = solve(prob, KrylovJL_MINRES()) #Will use the KrylovJL_MINRES solver from LinearSolve
+    @test sol ≈ b
+    sol = solve(prob, QF_LINEARSOLVE(KrylovJL_MINRES())) #Will use the KrylovJL_MINRES solver from LinearSolve
+    @test sol ≈ b
+    sol = solve(prob, KrylovJL_MINRES(); u0=rand(10)) # Set initial guess
+    @test sol ≈ b
+end
+
+
+@kwdef struct QF_LINEARSOLVE{A}
+    alg::A = nothing
 end

--- a/src/rayleigh_quotient.jl
+++ b/src/rayleigh_quotient.jl
@@ -86,7 +86,7 @@ function solve(prob::ConstrainedRayleighQuotientProblem, alg::RQ_EIG)
     b = prob.b
     C = prob.C
     Kb = I - b * b' / dot(b, b)
-    nlargest = partialsortperm(norm.(eachrow(b)), 1:size(b, 2), rev=true)
+    nlargest = partialsortperm(eachrow(b), 1:size(b, 2); by=norm, rev=true)
     N = size(b, 1)
     inds = map(!in(nlargest), 1:N)
     J = I(N)[inds, :]


### PR DESCRIPTION
LinearSolve is a heavy dependency, but is only used for solving the quadratic form problem. This PR makes it a weak dependency. The user can do `using LinearSolve` to be able to use it for solving the quadratic form.